### PR TITLE
Leviathan Mk2

### DIFF
--- a/Mod/DeckLists/Villains/LeviathanDeckList.json
+++ b/Mod/DeckLists/Villains/LeviathanDeckList.json
@@ -9,7 +9,6 @@
       "body": "Citykiller",
       "count": 1,
       "character": true,
-      "icons": [],
       "hitpoints": 100,
       "nemesisIdentifiers": [ "" ],
       "backgroundColor": "00cccc",
@@ -20,21 +19,32 @@
         "At the end of the villain turn, {Leviathan} deals 2 melee damage to all hero targets.",
         "At the end of the villain turn, if {Leviathan} has any Retaliation tokens remove all of them then flip Leviathan."
       ],
-      "flippedIcons": [],
+      "icons": [
+        "EndOfTurnAction",
+        "DestroyHero",
+        "AddTokens",
+        "DealDamageMelee",
+        "RemoveTokens"
+      ],
       "openingLines": {
         "default": "..."
       },
       "difficulty": 2,
       "advanced": "Reduce damage dealt to Leviathan by 1.",
-      "advancedIcons": "",
+      "advancedIcons": [ "ReduceDamageTaken" ],
       "flippedBody": "Citykiller Retaliates",
       "flippedGameplay": [
         "When flipped to this side reveal cards from the top of the villain deck until you reveal a Tactic card. Put it into play; shuffle the rest of the revealed cards back into the villain deck.",
         "At the start of the villain turn flip {Leviathan}.",
         "Reduce damage dealt to Leviathan by 1."
       ],
+      "flippedIcons": [
+        "Search",
+        "PlayCardNow",
+        "ReduceDamageTaken"
+      ],
       "flippedAdvanced": "The first time Leviathan would flip each turn play the top card of the villain deck first.",
-      "flippedAdvancedIcons": [],
+      "flippedAdvancedIcons": [ "PlayCardNow" ],
       "flippedNemesisIdentifiers": [ "" ],
       "tokenPools": [
         {
@@ -55,6 +65,7 @@
         "This card is indestructible.",
         "Whenever {LeviathanCharacter} deals melee damage to a target this card deals that target 2 irreducible melee damage."
       ],
+      "icons": [ "Indestructible", "DealDamageMelee" ],
       "flavorText": "Gallons of water poured around{BR}him in the wake of his movements, roughly{BR}the same amount of mass as the body part{BR}that had just occupied the space.",
       "flavorReference": "Extermination 8.2"
     },
@@ -64,6 +75,7 @@
       "count": 1,
       "keywords": [ "tactic" ],
       "body": [ "This card is indestructible.", "Whenever a player draws a card {LeviathanCharacter} deals that player's hero 1 cold damage." ],
+      "icons": [ "Indestructible", "DealDamageCold" ],
       "flavorText": "The windows were rattling with{BR}the force of the rain against them.",
       "flavorReference": "Extermination 8.2"
     },
@@ -76,6 +88,7 @@
         "This card is indestructible.",
         "At the start of the villain turn remove the top card of the environment deck from the game. Failing that, remove the top card of the environment trash. Failing that, remove an environment card in play. If no cards were removed the heroes lose the game."
       ],
+      "icons": [ "StartOfTurnAction", "Indestructible", "RemoveFromGame", "LoseTheGame" ],
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -90,6 +103,7 @@
       "count": 1,
       "keywords": [ "tactic" ],
       "body": [ "This card is indestructible.", "The first time {LeviathanCharacter} would be dealt damage each round prevent that damage." ],
+      "icons": [ "Indestructible", "CancelledDamageRed" ],
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -104,6 +118,7 @@
       "count": 2,
       "keywords": [ "ongoing" ],
       "body": "Increase damage dealt by villain cards by 1.",
+      "icons": [ "IncreaseDamageDealt" ],
       "flavorText": "Leviathan grabbed a car, twisted his{BR}entire upper body to toss it in{BR}the style of an olympic hammer-throw.",
       "flavorReference": "Extermination 8.5"
     },
@@ -113,6 +128,7 @@
       "count": 2,
       "keywords": [ "ongoing" ],
       "body": "Reduce damage dealt to {LeviathanCharacter} by 1.",
+      "icons": [ "ReduceDamageTaken" ],
       "flavorText": "Leviathan, nonstandard cardiac,{BR}nervous systems: irregular biology.{BR}No standard organs or weak points.",
       "flavorReference": "Interlude 8 (Bonus)"
     },
@@ -122,6 +138,7 @@
       "count": 2,
       "keywords": [ "ongoing" ],
       "body": "At the start of the villain turn shuffle the villain trash, then reveal cards from the top of the villain trash until you reveal a one-shot. Play it and then shuffle the other revealed cards back into the villain trash.",
+      "icons": [ "StartOfTurnAction", "Search", "PlayCardNow" ],
       "flavorText": "The Endbringer stood, showing none{BR}of the frailty or pain it had{BR}been displaying seconds ago.",
       "flavorReference": "Extermination 8.4"
     },
@@ -131,6 +148,7 @@
       "count": 3,
       "keywords": [ "one-shot" ],
       "body": [ "Destroy all environment targets.", "{LeviathanCharacter} deals X cold damage to all non-villain targets where X = 1 + the number of cards destroyed in this way." ],
+      "icons": [ "DestroyEnvironment", "DealDamageCold" ],
       "flavorText": "The building rocked with an impact,{BR}the forcefields to the left collapsed,{BR}and the water began to rush in",
       "flavorReference": "Extermination 8.2"
     },
@@ -140,6 +158,7 @@
       "count": 3,
       "keywords": [ "one-shot" ],
       "body": "Play the top 2 cards of the villain deck.",
+      "icons": [ "PlayCardNow" ],
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -154,6 +173,7 @@
       "count": 3,
       "keywords": [ "one-shot" ],
       "body": "{LeviathanCharacter} deals the hero target with the highest HP 5 irreducible melee damage.",
+      "icons": [ "DealDamageMelee" ],
       "flavorText": "Jotun deceased, CD-6{BR}Dauntless deceased, CD-6.{BR}Alabaster deceased, CD-6.",
       "flavorReference": "Extermination 8.3"
     },
@@ -163,6 +183,7 @@
       "count": 3,
       "keywords": [ "one-shot" ],
       "body": "Flip {LeviathanCharacter}.",
+      "icons": [ ],
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -177,6 +198,7 @@
       "count": 3,
       "keywords": [ "one-shot" ],
       "body": "{LeviathanCharacter} deals 2 melee damage to the 2 hero targets with the lowest HP.",
+      "icons": [ "DealDamageMelee" ],
       "flavorText": "Leviathan retaliated with a whiplike{BR}lash of his tail, bisecting the man. Of the{BR}twelve or so that had been on the roof{BR}a minute ago, only three remained.",
       "flavorReference": "Interlude 8 (Bonus)"
     }

--- a/Mod/DeckLists/Villains/LeviathanDeckList.json
+++ b/Mod/DeckLists/Villains/LeviathanDeckList.json
@@ -16,25 +16,35 @@
       "setup": [ "Put {Leviathan} into play 'Citykiller' side up. Reveal cards from the top of the villain deck until you reveal a Tactic card; put it into play. Shuffle the other cards back into the villain deck" ],
       "gameplay": [
         "When flipped to this side, destroy {H} noncharacter hero cards.",
+        "When Leviathan is dealt {8 - H} damage put a Retaliation token on Leviathan.",
         "At the end of the villain turn, {Leviathan} deals 2 melee damage to all hero targets.",
-        "At the end of the villain turn, if {Leviathan} has been dealt {8 - H} damage in one instance last round, flip {Leviathan}"
+        "At the end of the villain turn, if {Leviathan} has any Retaliation tokens remove all of them then flip Leviathan."
       ],
       "flippedIcons": [],
       "openingLines": {
         "default": "..."
       },
       "difficulty": 2,
-      "advanced": "Reduce damage dealt to Leviathan by 1",
+      "advanced": "Reduce damage dealt to Leviathan by 1.",
       "advancedIcons": "",
       "flippedBody": "Citykiller Retaliates",
       "flippedGameplay": [
         "When flipped to this side reveal cards from the top of the villain deck until you reveal a Tactic card. Put it into play; shuffle the rest of the revealed cards back into the villain deck.",
-        "At the start of the villain turn flip {Leviathan}",
-        "Reduce damage dealt to Leviathan by 1"
+        "At the start of the villain turn flip {Leviathan}.",
+        "Reduce damage dealt to Leviathan by 1."
       ],
-      "flippedAdvanced": "The first time Leviathan would flip each turn play the top card of the villain deck first",
+      "flippedAdvanced": "The first time Leviathan would flip each turn play the top card of the villain deck first.",
       "flippedAdvancedIcons": [],
-      "flippedNemesisIdentifiers": [ "" ]
+      "flippedNemesisIdentifiers": [ "" ],
+      "tokenPools": [
+        {
+          "identifier": "RetaliationPool",
+          "name": "Retaliation Pool",
+          "initialValue": 0,
+          "minimumValue": 0,
+          "color": ""
+        }
+      ]
     },
     {
       "identifier": "WaterShadow",

--- a/Mod/DeckLists/Villains/LeviathanDeckList.json
+++ b/Mod/DeckLists/Villains/LeviathanDeckList.json
@@ -13,7 +13,7 @@
       "hitpoints": 100,
       "nemesisIdentifiers": [ "" ],
       "backgroundColor": "00cccc",
-      "setup": [ "Put {Leviathan} into play 'Citykiller' side up. Reveal cards from the top of the villain deck until you reveal a Tactic card; put it into play. Shuffle the other cards back into the villain deck" ],
+      "setup": [ "Put {Leviathan} into play 'Citykiller' side up. Reveal cards from the top of the villain deck until you reveal a Tactic card; put it into play. Shuffle the other cards back into the villain deck." ],
       "gameplay": [
         "When flipped to this side, destroy {H} noncharacter hero cards.",
         "When Leviathan is dealt {8 - H} or more damage put a Retaliation token on Leviathan.",
@@ -89,7 +89,7 @@
       "title": "Faster Than You'd Think",
       "count": 1,
       "keywords": [ "tactic" ],
-      "body": [ "This card is indestructible", "The first time {LeviathanCharacter} would be dealt damage each round prevent that damage." ],
+      "body": [ "This card is indestructible.", "The first time {LeviathanCharacter} would be dealt damage each round prevent that damage." ],
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -103,7 +103,7 @@
       "title": "Impossible Strength",
       "count": 2,
       "keywords": [ "ongoing" ],
-      "body": "Increase damage dealt by villain cards by 1",
+      "body": "Increase damage dealt by villain cards by 1.",
       "flavorText": "Leviathan grabbed a car, twisted his{BR}entire upper body to toss it in{BR}the style of an olympic hammer-throw.",
       "flavorReference": "Extermination 8.5"
     },
@@ -112,7 +112,7 @@
       "title": "Impossible Toughness",
       "count": 2,
       "keywords": [ "ongoing" ],
-      "body": "Reduce damage dealt to {LeviathanCharacter} by 1",
+      "body": "Reduce damage dealt to {LeviathanCharacter} by 1.",
       "flavorText": "Leviathan, nonstandard cardiac,{BR}nervous systems: irregular biology.{BR}No standard organs or weak points.",
       "flavorReference": "Interlude 8 (Bonus)"
     },
@@ -121,7 +121,7 @@
       "title": "Impossible Endurance",
       "count": 2,
       "keywords": [ "ongoing" ],
-      "body": "At the start of the villain turn shuffle the villain trash, then reveal cards from the top of the villain trash until you reveal a one-shot. Play it and then shuffle the other revealed cards back into the villain trash",
+      "body": "At the start of the villain turn shuffle the villain trash, then reveal cards from the top of the villain trash until you reveal a one-shot. Play it and then shuffle the other revealed cards back into the villain trash.",
       "flavorText": "The Endbringer stood, showing none{BR}of the frailty or pain it had{BR}been displaying seconds ago.",
       "flavorReference": "Extermination 8.4"
     },
@@ -130,7 +130,7 @@
       "title": "Tidal Wave",
       "count": 3,
       "keywords": [ "one-shot" ],
-      "body": [ "Destroy all environment targets.", "{LeviathanCharacter} deals X cold damage to all non-villain targets where X = 1 + the number of cards destroyed in this way" ],
+      "body": [ "Destroy all environment targets.", "{LeviathanCharacter} deals X cold damage to all non-villain targets where X = 1 + the number of cards destroyed in this way." ],
       "flavorText": "The building rocked with an impact,{BR}the forcefields to the left collapsed,{BR}and the water began to rush in",
       "flavorReference": "Extermination 8.2"
     },
@@ -139,7 +139,7 @@
       "title": "Cunning",
       "count": 3,
       "keywords": [ "one-shot" ],
-      "body": "Play the top 2 cards of the villain deck",
+      "body": "Play the top 2 cards of the villain deck.",
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -153,7 +153,7 @@
       "title": "Anyone Can Die",
       "count": 3,
       "keywords": [ "one-shot" ],
-      "body": "{LeviathanCharacter} deals the hero target with the highest HP 5 irreducible melee damage",
+      "body": "{LeviathanCharacter} deals the hero target with the highest HP 5 irreducible melee damage.",
       "flavorText": "Jotun deceased, CD-6{BR}Dauntless deceased, CD-6.{BR}Alabaster deceased, CD-6.",
       "flavorReference": "Extermination 8.3"
     },
@@ -162,7 +162,7 @@
       "title": "Guile",
       "count": 3,
       "keywords": [ "one-shot" ],
-      "body": "Flip {LeviathanCharacter}",
+      "body": "Flip {LeviathanCharacter}.",
       "flavorQuotes": [
         {
           "identifier": "Legend",
@@ -176,7 +176,7 @@
       "title": "Whipping Tail",
       "count": 3,
       "keywords": [ "one-shot" ],
-      "body": "{LeviathanCharacter} deals 2 melee damage to the 2 hero targets with the lowest HP",
+      "body": "{LeviathanCharacter} deals 2 melee damage to the 2 hero targets with the lowest HP.",
       "flavorText": "Leviathan retaliated with a whiplike{BR}lash of his tail, bisecting the man. Of the{BR}twelve or so that had been on the roof{BR}a minute ago, only three remained.",
       "flavorReference": "Interlude 8 (Bonus)"
     }

--- a/Mod/DeckLists/Villains/LeviathanDeckList.json
+++ b/Mod/DeckLists/Villains/LeviathanDeckList.json
@@ -16,7 +16,7 @@
       "setup": [ "Put {Leviathan} into play 'Citykiller' side up. Reveal cards from the top of the villain deck until you reveal a Tactic card; put it into play. Shuffle the other cards back into the villain deck" ],
       "gameplay": [
         "When flipped to this side, destroy {H} noncharacter hero cards.",
-        "When Leviathan is dealt {8 - H} damage put a Retaliation token on Leviathan.",
+        "When Leviathan is dealt {8 - H} or more damage put a Retaliation token on Leviathan.",
         "At the end of the villain turn, {Leviathan} deals 2 melee damage to all hero targets.",
         "At the end of the villain turn, if {Leviathan} has any Retaliation tokens remove all of them then flip Leviathan."
       ],

--- a/Mod/DeckLists/Villains/LeviathanDeckList.json
+++ b/Mod/DeckLists/Villains/LeviathanDeckList.json
@@ -73,10 +73,8 @@
       "count": 1,
       "keywords": [ "tactic" ],
       "body": [
-        "This card is indestructible",
-        "If the environment deck is ever empty {LeviathanCharacter} has destroyed the area. [b]GAME OVER[/b].",
-        "At the end of the villain turn remove the top card of the environment deck from the game.",
-        "Players may skip any of their phases to take a card from the environment trash and shuffle it into the environment deck"
+        "This card is indestructible.",
+        "At the start of the villain turn remove the top card of the environment deck from the game. Failing that, remove the top card of the environment trash. Failing that, remove an environment card in play. If no cards were removed the heroes lose the game."
       ],
       "flavorQuotes": [
         {
@@ -123,7 +121,7 @@
       "title": "Impossible Endurance",
       "count": 2,
       "keywords": [ "ongoing" ],
-      "body": "At the start of the villain turn reveal cards from the top of the villain trash until you reveal a one-shot. Play it and then shuffle the other revealed cards back into the villain trash",
+      "body": "At the start of the villain turn shuffle the villain trash, then reveal cards from the top of the villain trash until you reveal a one-shot. Play it and then shuffle the other revealed cards back into the villain trash",
       "flavorText": "The Endbringer stood, showing none{BR}of the frailty or pain it had{BR}been displaying seconds ago.",
       "flavorReference": "Extermination 8.4"
     },

--- a/Mod/Villains/Leviathan/Cards/ImpossibleEnduranceCardController.cs
+++ b/Mod/Villains/Leviathan/Cards/ImpossibleEnduranceCardController.cs
@@ -15,7 +15,7 @@ namespace Jp.ParahumansOfTheWormverse.Leviathan
 
         public override void AddTriggers()
         {
-            // At the start of the villain turn, reveal cards from the top of the villain trash until you reveal a one-shot.
+            // At the start of the villain turn, shuffle the villain trash then reveal cards from the top of the villain trash until you reveal a one-shot.
             // Play it, and then shuffle the other revealed cards back into the villain trash
             AddStartOfTurnTrigger(
                 tt => tt == TurnTaker,
@@ -26,7 +26,11 @@ namespace Jp.ParahumansOfTheWormverse.Leviathan
 
         private IEnumerator FindOneShot(PhaseChangeAction pca)
         {
-            return RevealCards_MoveMatching_ReturnNonMatchingCards(
+            var e = ShuffleDeck(DecisionMaker, TurnTaker.Trash);
+            if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+            else { GameController.ExhaustCoroutine(e); }
+
+            e = RevealCards_MoveMatching_ReturnNonMatchingCards(
                 TurnTakerController,
                 TurnTaker.Trash,
                 playMatchingCards: true,
@@ -36,6 +40,8 @@ namespace Jp.ParahumansOfTheWormverse.Leviathan
                 numberOfMatches: 1,
                 revealedCardDisplay: RevealedCardDisplay.ShowMatchingCards
             );
+            if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
+            else { GameController.ExhaustCoroutine(e); }
         }
     }
 }


### PR DESCRIPTION
Makes a couple Leviathan changes:
- Changes the way he flips so that he gets tokens and then flips if he has a token. This should prevent flip-flip back without Guile getting involved, gives a hook for potential future Challenge rules, and makes it more obvious if you've triggered his flip behaviour.
- Changes Lose the War to not lose the game when combined with reveal effects and to be less talkative.
- Changes Impossible Endurance to shuffle the trash first so you don't actually need to track trash position
- Adds icons and full stops to the decklist