### PR TITLE
Fixes for Battery Cauldron Cape's discharge interaction with getting swapped out

### DIFF
--- a/Mod/Heroes/Battery/Characters/BatteryCauldronCapeCharacterCardController.cs
+++ b/Mod/Heroes/Battery/Characters/BatteryCauldronCapeCharacterCardController.cs
@@ -71,17 +71,8 @@ namespace Jp.ParahumansOfTheWormverse.Battery
 
         private IEnumerator DischargeBattery()
         {
-            // {Charge} {BatteryCharacter}...
-            var e = this.ChargeCard(CharacterCard);
-            if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
-            else { GameController.ExhaustCoroutine(e); }
-
-            // ... until the start of your next turn.
-            OnPhaseChangeStatusEffect chargeExpiration = new OnPhaseChangeStatusEffect(Card, nameof(ChargeExpiresResponse), "At the start of " + HeroTurnTakerController.Name + "'s next turn, {Discharge} " + Card.Title + ".", new TriggerType[] { TriggerType.ModifyStatusEffect }, Card);
-            chargeExpiration.BeforeOrAfter = BeforeOrAfter.After;
-            chargeExpiration.UntilStartOfNextTurn(TurnTaker);
-
-            e = GameController.AddStatusEffect(chargeExpiration, true, GetCardSource());
+            // {Charge} {BatteryCharacter} until the start of your next turn.
+            var e = this.ChargeCard(CharacterCard, true);
             if (UseUnityCoroutines) { yield return GameController.StartCoroutine(e); }
             else { GameController.ExhaustCoroutine(e); }
 

--- a/Mod/Heroes/Battery/Extra/BatteryChargedStatusEffect.cs
+++ b/Mod/Heroes/Battery/Extra/BatteryChargedStatusEffect.cs
@@ -12,10 +12,10 @@ using Handelabra.Sentinels.Engine.Model;
 namespace Jp.ParahumansOfTheWormverse.Battery
 {
     [Serializable]
-    public class BatteryChargedStatusEffect : ReflectionStatusEffect
+    public class BatteryChargedStatusEffect : OnPhaseChangeStatusEffect
     {
-        public BatteryChargedStatusEffect(Card cardWithMethod, string nameOfMethod, Card cardSource, Card chargedCard)
-            : base(cardWithMethod, nameOfMethod, $"{chargedCard.Title} is charged", new TriggerType[] { TriggerType.Other }, cardSource)
+        public BatteryChargedStatusEffect(Card cardWithMethod, string nameOfMethod, Card cardSource, Card chargedCard, bool temporary)
+            : base(cardWithMethod, nameOfMethod, GetStatusEffectDescription(chargedCard, temporary), new TriggerType[] { TriggerType.Other }, cardSource)
         {
             TargetLeavesPlayExpiryCriteria.IsOneOfTheseCards = new List<Card> { chargedCard };
         }
@@ -25,6 +25,13 @@ namespace Jp.ParahumansOfTheWormverse.Battery
         public override string ToString()
         {
             return Description;
+        }
+
+        public static string GetStatusEffectDescription(Card chargedCard, bool temporary)
+        {
+            string ret = $"{chargedCard.Title} is charged";
+            if (temporary) ret += " until the start of their next turn.";
+            return ret;
         }
     }
 }

--- a/Mod/Heroes/Battery/Extra/BatteryExtensions.cs
+++ b/Mod/Heroes/Battery/Extra/BatteryExtensions.cs
@@ -10,9 +10,12 @@ namespace Jp.ParahumansOfTheWormverse.Battery
 
     public static class BatteryExtensions
     {
-        public static IEnumerator ChargeCard(this CardController source, Card toCharge)
+        public static IEnumerator ChargeCard(this CardController source, Card toCharge, bool expireNextTurn = false)
         {
-            var effect = new BatteryChargedStatusEffect(source.CardWithoutReplacements, "", source.Card, toCharge);
+            var effect = new BatteryChargedStatusEffect(source.CardWithoutReplacements, "", source.Card, toCharge, expireNextTurn);
+            if (expireNextTurn)
+                effect.UntilStartOfNextTurn(source.TurnTaker);
+
             var e = source.GameController.AddStatusEffect(effect, showMessage: true, cardSource: source.GetCardSource());
             if (source.UseUnityCoroutines) { yield return source.GameController.StartCoroutine(e); }
             else { source.GameController.ExhaustCoroutine(e); }

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -506,7 +506,7 @@ namespace Handelabra.Sentinels.UnitTest
             var modDefs = ModHelper.GetAllPromoDefinitions();
 
             // Find all the playable hero character cards in the box (including other sizes of Sky-Scraper)
-            var availableHeroes = DeckDefinition.AvailableHeroes;
+            var availableHeroes = DeckDefinition.AvailableHeroes.Union(GameController.Game.HeroTurnTakers.Select(tt => tt.DeckDefinition.QualifiedIdentifier));
             foreach (var heroTurnTaker in availableHeroes.Where(turnTakerCriteria))
             {
                 var heroDefinition = DeckDefinitionCache.GetDeckDefinition(heroTurnTaker);

--- a/Test/Heroes/Battery/BatteryCauldronCapeTests.cs
+++ b/Test/Heroes/Battery/BatteryCauldronCapeTests.cs
@@ -17,6 +17,39 @@ namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
     public class BatteryCauldronCapeTests : ParahumanTest
     {
         [Test()]
+        public void TestDischargeAtEndOfTurn()
+        {
+            SetupGameController(
+                new string[] { "BaronBlade", "Jp.ParahumansOfTheWormverse.Battery", "Megalopolis" },
+                promoIdentifiers: new Dictionary<string, string> { { "Jp.ParahumansOfTheWormverse.Battery", "BatteryCauldronCapeCharacter" } }
+            );
+
+            StartGame();
+
+            RemoveVillainCards();
+            RemoveVillainTriggers();
+
+            GoToUsePowerPhase(battery);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.False);
+
+            AssertNumberOfStatusEffectsInPlay(0);
+            UsePower(battery, 1);
+            AssertNumberOfStatusEffectsInPlay(1);
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+
+            GoToEndOfTurn(battery);
+
+            AssertNumberOfStatusEffectsInPlay(1);
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+
+            GoToStartOfTurn(battery);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.False);
+            AssertNumberOfStatusEffectsInPlay(0);
+        }
+
+        [Test()]
         public void TestFaceDownACard()
         {
             SetupGameController(
@@ -73,17 +106,29 @@ namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
 
             StartGame();
 
-            DestroyNonCharacterVillainCards();
+            RemoveVillainCards();
+            RemoveVillainTriggers();
+
             MoveAllCardsFromHandToDeck(battery);
 
             StackDeck("Strength");
 
             UsePower(battery, 0);
 
+            GoToUsePowerPhase(battery);
+
             DecisionSelectTarget = baron.CharacterCard;
             QuickHPStorage(baron);
             UsePower(battery, 1);
-            QuickHPCheck(-5);            
+            QuickHPCheck(-5);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+            AssertNumberOfStatusEffectsInPlay(1);
+
+            GoToStartOfTurn(battery);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.False);
+            AssertNumberOfStatusEffectsInPlay(0);
         }
 
         [Test()]
@@ -186,6 +231,23 @@ namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
             AssertNotFlipped(threadsOnDeck);
             AssertInTrash(threadsOnDeck);
             QuickHPCheck(-5);
+        }
+
+        [Test()]
+        public void TestSwitchingCharacterCardsDoesntUncharge()
+        {
+            SetupGameController("BaronBlade", "Jp.ParahumansOfTheWormverse.Battery/BatteryCauldronCapeCharacter", "Guise/CompletionistGuiseCharacter", "InsulaPrimalis");
+
+            StartGame();
+
+            UsePower(battery.CharacterCard, 1);
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+
+            DecisionSelectCards = new Card[] { battery.CharacterCard, battery.CharacterCard };
+            UsePower(guise);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+            Assert.That(battery.CharacterCard.PromoIdentifierOrIdentifier, Is.EqualTo("BatteryCharacter"));
         }
     }
 }

--- a/Test/Heroes/Battery/BatteryTests.cs
+++ b/Test/Heroes/Battery/BatteryTests.cs
@@ -7,6 +7,9 @@ using System.Collections;
 using System.Collections.Generic;
 using Handelabra.Sentinels.UnitTest;
 using Jp.ParahumansOfTheWormverse.Battery;
+using Handelabra;
+using Handelabra.Sentinels.Engine.Controller.TheCelestialTribunal;
+using System.Runtime.InteropServices;
 
 namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
 {
@@ -54,6 +57,142 @@ namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
 
             Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.False);
             AssertNumberOfUsablePowers(battery.CharacterCard, 0);
+        }
+
+        [Test()]
+        public void TestSwitchingCharacterCardsDoesntUncharge()
+        {
+            SetupGameController("BaronBlade", "Jp.ParahumansOfTheWormverse.Battery", "Guise/CompletionistGuiseCharacter", "InsulaPrimalis");
+
+            StartGame();
+
+            UsePower(battery.CharacterCard);
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+
+            DecisionSelectCards = new Card[] { battery.CharacterCard, battery.CharacterCard };
+            UsePower(guise);
+
+            Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+            Assert.That(battery.CharacterCard.PromoIdentifierOrIdentifier, Is.EqualTo("BatteryCauldronCapeCharacter"));
+        }
+
+        [Test()]
+        public void GetBothCharges()
+        {
+            SetupGameController("BaronBlade", "Jp.ParahumansOfTheWormverse.Battery", "TheCelestialTribunal");
+
+            StartGame();
+
+            RemoveVillainCards();
+            RemoveVillainTriggers();
+
+            //UsePower(battery.CharacterCard);
+            //Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
+
+            //DecisionSelectFromBoxIdentifiers = new string[] { "Jp.ParahumansOfTheWormverse.BatteryCauldronCapeCharacter" };
+            //DecisionSelectFromBoxTurnTakerIdentifier = "Jp.ParahumansOfTheWormverse.Battery";
+
+            DecisionSelectFromBoxIdentifiers = new string[] { "TachyonCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Tachyon";
+            DecisionSelectCard = battery.CharacterCard;
+            //DecisionSelectPowerIndex = 1;
+            PlayCard("CalledToJudgement");
+
+            
+
+            Log.Debug("Trying to use power directly");
+
+            var rep = FindCard(c => c.Location.IsPlayAreaOf(env.TurnTaker) && c.IsHeroCharacterCard);
+            var repOfEarth = FindCard(c => c.Identifier == "RepresentativeOfEarth");
+            Log.Debug($"Rep: {rep}");
+            var e = GameController.SelectAndUsePower(
+                battery,
+                optional: true,
+                (Power power) => power.CardSource != null && power.CardSource.Card == rep,
+                1,
+                eliminateUsedPowers: false,
+                null,
+                showMessage: false,
+                allowAnyHeroPower: true,
+                allowReplacements: true,
+                canBeCancelled: true,
+                null,
+                forceDecision: false,
+                allowOutOfPlayPower: false,
+                FindCardController(repOfEarth).GetCardSource()
+            );
+            RunCoroutine(e);
+
+            IEnumerable<Power> possiblePowers =
+                GameController.GetUsablePowersThisTurn(
+                    battery,
+                    eliminateUsedPowers: false,
+                    allowAnyHeroPower: true,
+                    allowReplacements: true,
+                    canBeCancelled: true,
+                    allowOutOfPlayPower: false,
+                    null,
+                    battery.CharacterCardController.GetCardSource()
+                ).Where(p => p.CardSource != null & p.CardSource.Card == rep);
+
+            Log.Debug("Powers:");
+            foreach (var p in possiblePowers)
+            { Log.Debug($"\t{p}"); }
+        }
+
+        [Test()]
+        public void LegacyJudgement()
+        {
+            SetupGameController("BaronBlade", "Legacy", "TheCelestialTribunal");
+
+            StartGame();
+
+            RemoveVillainCards();
+            RemoveVillainTriggers();
+
+            DecisionSelectFromBoxIdentifiers = new string[] { "TachyonCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Tachyon";
+            DecisionSelectCard = legacy.CharacterCard;
+            PlayCard("CalledToJudgement");
+        }
+
+        [Test()]
+        public void BatteryJudgement()
+        {
+            SetupGameController("BaronBlade", "Jp.ParahumansOfTheWormverse.Battery", "TheCelestialTribunal");
+
+            StartGame();
+
+            RemoveVillainCards();
+            RemoveVillainTriggers();
+
+            DecisionSelectFromBoxIdentifiers = new string[] { "TachyonCharacter" };
+            DecisionSelectFromBoxTurnTakerIdentifier = "Tachyon";
+            DecisionSelectCard = battery.CharacterCard;
+            PlayCard("CalledToJudgement");
+
+            Log.Debug("Trying to use power directly");
+
+            var rep = FindCard(c => c.Location.IsPlayAreaOf(env.TurnTaker) && c.IsHeroCharacterCard);
+            var repOfEarth = FindCard(c => c.Identifier == "RepresentativeOfEarth");
+            Log.Debug($"Rep: {rep}");
+            var e = GameController.SelectAndUsePower(
+                battery,
+                optional: true,
+                (Power power) => power.CardSource != null && power.CardSource.Card == rep,
+                1,
+                eliminateUsedPowers: false,
+                null,
+                showMessage: false,
+                allowAnyHeroPower: true,
+                allowReplacements: true,
+                canBeCancelled: true,
+                null,
+                forceDecision: false,
+                allowOutOfPlayPower: false,
+                FindCardController(repOfEarth).GetCardSource()
+            );
+            RunCoroutine(e);
         }
     }
 }

--- a/Test/Heroes/Battery/GlowingThreadsTests.cs
+++ b/Test/Heroes/Battery/GlowingThreadsTests.cs
@@ -77,8 +77,8 @@ namespace Jp.ParahumansOfTheWormverse.UnitTest.Battery
             UsePower(battery, 1);
             Assert.That(battery.CharacterCardController.IsCharged(battery.CharacterCard), Is.True);
 
-            // + charge effect, + damage reduce effect, + delayed discharge effect
-            AssertNumberOfStatusEffectsInPlay(3);
+            // + charge effect, + damage reduce effect
+            AssertNumberOfStatusEffectsInPlay(2);
 
             DealDamage(battery, battery, 2, DamageType.Infernal);
             QuickHPCheck(0);


### PR DESCRIPTION
If Cauldron Cape discharged, the discharge-battery-later status effect would persist if battery is swapped out for a different variant.